### PR TITLE
fix: modernize typing and simplify control flow in core modules

### DIFF
--- a/src/pynamer/builder.py
+++ b/src/pynamer/builder.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from importlib.resources import as_file
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 # Third party modules
 import build
@@ -85,14 +85,13 @@ def create_setup(new_project_name: str, new_meta: bool = False) -> None:
                 )
                 if re.search(_email_pattern, email):
                     break
-                else:
-                    print(
-                        Fore.YELLOW
-                        + Back.BLACK
-                        + Style.BRIGHT
-                        + "does not appear to be a valid email address"
-                        + Style.RESET_ALL
-                    )  # pragma: no cover
+                print(
+                    Fore.YELLOW
+                    + Back.BLACK
+                    + Style.BRIGHT
+                    + "does not appear to be a valid email address"
+                    + Style.RESET_ALL
+                )  # pragma: no cover
         except KeyboardInterrupt as e:  # pragma: no cover
             feedback("...bye!", "warning")
             raise SystemExit() from e
@@ -238,8 +237,8 @@ def cleanup(project_name: str) -> None:
 def run_command(
     *arguments: str,
     shell: bool = True,
-    working_dir: Union[Path, str, None] = None,
-    project: Union[None, str] = None,
+    working_dir: Path | str | None = None,
+    project: None | str = None,
 ) -> None:  # pragma: no cover
     """Utility designed to execute a command line utility.
 

--- a/src/pynamer/config.py
+++ b/src/pynamer/config.py
@@ -3,7 +3,6 @@
 # Core Library modules
 import sys
 from pathlib import Path
-from typing import Optional
 
 # Local modules
 from . import project_count
@@ -12,7 +11,7 @@ from . import project_count
 class Config:
     """Configuration class"""
 
-    pypirc: Optional[Path] = None
+    pypirc: Path | None = None
     original_project_name: str = "project_name"
     no_cleanup: bool = False
     project_count: int = project_count

--- a/src/pynamer/exceptions.py
+++ b/src/pynamer/exceptions.py
@@ -1,5 +1,6 @@
 # Core Library modules
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 # Third party modules
 from requests import (

--- a/src/pynamer/utils.py
+++ b/src/pynamer/utils.py
@@ -8,7 +8,7 @@ import pickle
 import re
 from importlib.resources import as_file
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 # Third party modules
 import requests
@@ -206,7 +206,7 @@ def check_version() -> None:
 
 
 @file_exception
-def process_input_file(file: str) -> list[Union[str, Any]]:
+def process_input_file(file: str) -> list[str | Any]:
     """Processes the contents of the file to a list of strings.
 
     Args:

--- a/src/pynamer/validators.py
+++ b/src/pynamer/validators.py
@@ -6,7 +6,7 @@ import json
 import re
 import string
 from datetime import datetime
-from typing import Any, Union
+from typing import Any
 
 # Third party modules
 import requests
@@ -32,11 +32,10 @@ def is_valid_package_name(project_name: str) -> bool:
         True:           If the name passes the basic check
         False:          If the name fails the basic check
     """
-    pattern = re.compile("^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.I)
+    pattern = re.compile(r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.I)
     if re.match(pattern, project_name) is not None:
         return True
-    else:
-        return False
+    return False
 
 
 def get_homepage(project_json: dict, project_name: str) -> tuple[str, str]:
@@ -236,7 +235,7 @@ def pypi_search_index(project_name: str) -> bool:
 
 def pypi_search(
     search_project: str,
-) -> tuple[list[list[Union[str, Any]]], list[list[Union[str, Any]]], str]:
+) -> tuple[list[list[str | Any]], list[list[str | Any]], str]:
     """Performs a get request to PyPI's search API for the project name.
 
     Args:

--- a/tasks.py
+++ b/tasks.py
@@ -365,7 +365,7 @@ def tests(c, open_browser=False):
     _clean_test()
     print(TEST_DIR)
     c.run(
-        f'pytest "{str(TEST_DIR)}" --cov=pynamer --cov-report=html'
+        f'pytest "{TEST_DIR!s}" --cov=pynamer --cov-report=html'
         f" --html=pytest-report.html -ra"
     )
     if open_browser:

--- a/templater.py
+++ b/templater.py
@@ -2,7 +2,7 @@
 # Core Library modules
 import re
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 # Third party modules
 import requests
@@ -14,7 +14,7 @@ env_file = "".join([Path(__file__).stem, ".env"])
 
 def write_to_env_file(key: str, value: str) -> None:  # type: ignore
     entry = "".join([key, "=", value, "\n"])
-    with open(env_file, mode="a") as file:
+    with Path(env_file).open(mode="a") as file:
         file.write(entry)
 
 
@@ -36,7 +36,7 @@ def get_value1() -> None:
                 if "projects" in text:
                     break
 
-        match: Optional[re.Match] = re.search(pattern, text)
+        match: re.Match | None = re.search(pattern, text)
         if match is not None:
             matched_text: str = match.group()
             write_to_env_file("PROJECT_COUNT_HYPHEN", matched_text)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ setup(name='{{ PROJECT_NAME }}',
       zip_safe=False)"""
 
 
-@pytest.fixture()
+@pytest.fixture
 def src_reset():
     meta = SRC_DIR / "meta.pickle"
     count = SRC_DIR / "project_count.pickle"
@@ -43,7 +43,7 @@ def src_reset():
     shutil.copy(base_setup, setup)
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_env():
     project_dir = BASE_DIR / "project_name"
     project_dir.mkdir()
@@ -71,13 +71,13 @@ def create_env():
                 item.unlink()
 
 
-@pytest.fixture()
+@pytest.fixture
 def path_mock(mocker):
     mocker.patch.dict(os.environ, {"PATH": str(BASE_DIR)})
     mocker.patch("os.getcwd", return_value=str(BASE_DIR))
 
 
-@pytest.fixture()
+@pytest.fixture
 def project_path_mock(monkeypatch):
     monkeypatch.setattr(pynamer, "project_path", BASE_DIR)
 

--- a/tests/test_build_dist.py
+++ b/tests/test_build_dist.py
@@ -27,7 +27,7 @@ setup(name='pynamer',
       zip_safe=False)"""
 
 
-@pytest.fixture()
+@pytest.fixture
 def pre_build_dist(monkeypatch):
     project_dir = BASE_DIR / "pynamer"
     project_dir.mkdir()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -12,7 +12,7 @@ from pynamer import builder, pynamer
 BASE_DIR = Path(__file__).parents[0]
 
 
-@pytest.fixture()
+@pytest.fixture
 def pre_cleanup(monkeypatch):
     project_dir = BASE_DIR / "pynamer"
     project_dir.mkdir()

--- a/tests/test_create_setup_file.py
+++ b/tests/test_create_setup_file.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 # First party modules
-from pynamer import builder, pynamer
+from pynamer import builder
 
 BASE_DIR = Path(__file__).parents[0]
 expected_content = """#!/usr/bin/env python3
@@ -34,7 +34,7 @@ def test_create_setup(create_env, monkeypatch):
     builder.create_setup("pynball")
 
     setup_file = BASE_DIR / "setup.py"
-    with open(setup_file, encoding="utf-8") as f:
+    with Path(setup_file).open(encoding="utf-8") as f:
         contents = f.read()
     assert contents == expected_content
 

--- a/tests/test_delete_director.py
+++ b/tests/test_delete_director.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 # First party modules
-from pynamer import builder, pynamer
+from pynamer import builder
 
 BASE_DIR = Path(__file__).parents[0]
 

--- a/tests/test_generate_pypi_index.py
+++ b/tests/test_generate_pypi_index.py
@@ -9,7 +9,7 @@ import requests
 from requests.exceptions import ConnectTimeout
 
 # First party modules
-from pynamer import pynamer, utils
+from pynamer import utils
 
 BASE_DIR = Path(__file__).parents[0]
 

--- a/tests/test_get_homepage.py
+++ b/tests/test_get_homepage.py
@@ -1,13 +1,8 @@
 #!/usr/bin/env python3
 # Core Library modules
-import pickle
 from pathlib import Path
 
 # Third party modules
-import pytest
-import requests
-from requests.exceptions import ConnectTimeout
-
 # First party modules
 import pynamer
 

--- a/tests/test_rename_project_dir.py
+++ b/tests/test_rename_project_dir.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 # First party modules
-from pynamer import builder, pynamer
+from pynamer import pynamer
 
 BASE_DIR = Path(__file__).parents[0]
 

--- a/tests/test_write_output_file.py
+++ b/tests/test_write_output_file.py
@@ -14,9 +14,9 @@ def test_write_output_file(monkeypatch):
     result_dict = {"pyball": [1, 1, 1]}
     pynamer.write_output_file(str(output_file), result_dict)
 
-    with open(expected_results_file) as f:
+    with Path(expected_results_file).open() as f:
         expected_text = f.read()
-    with open(output_file) as f:
+    with Path(output_file).open() as f:
         result_text = f.read()
 
     assert result_text == expected_text

--- a/tools/hasher.py
+++ b/tools/hasher.py
@@ -1,10 +1,11 @@
 # Core Library modules
 import hashlib
+import pathlib
 
 
 def calculate_md5(filepath):
     md5_hash = hashlib.md5()
-    with open(filepath, "rb") as file:
+    with pathlib.Path(filepath).open("rb") as file:
         # Read the file in chunks to handle large files efficiently
         for chunk in iter(lambda: file.read(4096), b""):
             md5_hash.update(chunk)

--- a/tools/pickle_save_utility.py
+++ b/tools/pickle_save_utility.py
@@ -22,7 +22,7 @@ def ping_project(name):
     )
     url = "".join([pypi_project_url, name, "/"])
     r = requests.get(url, timeout=5)
-    with open(ping_file_name, "wb") as f:
+    with Path(ping_file_name).open("wb") as f:
         pickle.dump(r, f)
 
 
@@ -36,7 +36,7 @@ def json_save(name):
     url = "".join([pypi_json_url, name, "/json"])
     r = requests.get(url, timeout=5)
     # j = r.content.decode('utf-8')
-    with open(json_file_name, "wb") as f:
+    with Path(json_file_name).open("wb") as f:
         pickle.dump(r, f)
 
 
@@ -47,7 +47,7 @@ def json_open(name):
         / "resources"
         / "".join(["requests_get_json_", name, ".pickle"])
     )
-    with open(json_file_name, "rb") as f:
+    with Path(json_file_name).open("rb") as f:
         response = pickle.load(f)
     print(type(response))
     print(response.status_code)
@@ -68,7 +68,7 @@ def search(name):
     )
     params = {"q": {name}, "page": 1}
     r = requests.get(pypi_search_url, params=params, timeout=5)
-    with open(search_file_name, "wb") as f:
+    with Path(search_file_name).open("wb") as f:
         pickle.dump(r, f)
 
 
@@ -104,7 +104,7 @@ def manual_simple_index():
     response.status_code = 200
     response.headers = {"Content-Type": "application/json"}
     response._content = small_content
-    with open(index_file_name, "wb") as f:
+    with Path(index_file_name).open("wb") as f:
         pickle.dump(response, f)
 
 
@@ -122,7 +122,7 @@ def get_github_meta(url):
     print(repo_api_url)
     try:
         json_raw = requests.get(repo_api_url, timeout=5)
-    except requests.RequestException as e:
+    except requests.RequestException:
         return "".join([return_text, "GitHub can not be contacted."])
     if json_raw.status_code == 200:
         repo_json = json_raw.json()
@@ -142,7 +142,7 @@ def get_github_meta(url):
                 f"updated: {isoparse(repo_json['updated_at']).date()}",
             ]
         )
-    elif json_raw.status_code == 404:
+    if json_raw.status_code == 404:
         return "".join([return_text, "GitHub reports repository does not exist."])
 
 
@@ -163,7 +163,7 @@ def save_github_meta(url, project_name):
         )
     request_response = requests.get(repo_api_url, timeout=5)
     content = request_response.content
-    with open(json_file_name, "wb") as f:
+    with Path(json_file_name).open("wb") as f:
         pickle.dump(request_response, f)
 
 


### PR DESCRIPTION
## Summary

**Repo health:** 20/100

Our analysis found **19 format issues** and about **62 refactoring opportunities** across the reviewed scope. Security scans (gitleaks, bandit) reported no confirmed secrets or high-severity patterns in your Python sources; duplication is moderate (~5.1% in Python per jscpd, above the 2% gate threshold); maintainability index and cyclomatic complexity passed radon gates; most remaining items are style lint (ruff) and optional structural refactors.

This pull request is a **sample** of those findings — 18 files with roughly 98 focused line changes — and is not a complete format pass or refactor cleanup.

## What you are doing right

- No secrets or high-severity security patterns showed up in the scanned Python scope (bandit).
- Maintainability index and cyclomatic complexity look good — radon did not flag modules or blocks in scope.
- The core `pynamer` package is well-tested (95% coverage locally on 64 tests).

## What you could improve

- **Duplication (~5.1% in Python):** There is duplicate code across the repo — examples include repeated CLI argument patterns in `tasks.py` and repeated Rich markup strings in `src/pynamer/pynamer.py` and `src/pynamer/validators.py`. *(follow-up)*
- **Refactoring (~62 opportunities):** About 62 structural refactor suggestions remain — e.g. simplify nested conditionals in `src/pynamer/builder.py:create_setup`, use subscript access for regex groups in `src/pynamer/validators.py`, and extract repeated string constants in `tasks.py`. *(partially addressed in example PR where safe auto-fix applied)*
- **Dependencies (deptry):** `beautifulsoup4`, `python-dateutil`, `twine`, and `wheel` are declared but not imported in the main package tree — they may be CLI/runtime-only; worth confirming or scoping as optional extras. *(follow-up)*
- **Lint / style (ruff):** Modernize `typing.Union` to PEP 604 `|` syntax, remove unnecessary `else` after `break`, and tidy import ordering — **included in example PR** across `src/pynamer/`, tests, and `tools/`.
- **Subprocess usage:** `run_command` in `src/pynamer/builder.py` defaults to `shell=True` — bandit flags this pattern; consider argv lists if inputs are not fully trusted. *(follow-up — not changed in this PR)*

## Changes

- `src/pynamer/builder.py`: PEP 604 union types; remove unnecessary `else` after `break` in email validation loop
- `src/pynamer/config.py`, `exceptions.py`, `utils.py`, `validators.py`: typing modernization and minor ruff cleanups
- `tests/conftest.py` and 8 test modules: import ordering and minor style fixes
- `tasks.py`, `templater.py`, `tools/hasher.py`, `tools/pickle_save_utility.py`: safe ruff auto-fixes in supporting code
---
*Review summary produced with [ShipGate](https://github.com/inquilabee/shipgate) — a policy-first quality orchestrator that runs linters, formatters, security scanners, and refactor checks from one catalog. This PR used `check` + `refactor check --strict` to find issues; [docs](https://inquilabee.github.io/shipgate/).*